### PR TITLE
Use opencv instead of libopencv

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   git_rev: {{ version }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and py2k]
   merge_build_host: True  # [win]
   script:
@@ -25,7 +25,8 @@ requirements:
   host:
     - pip
     - python
-    - libopencv
+    - libopencv  # [win]
+    - opencv  # [not win]
     - mkl-devel
     - scikit-build
     - setuptools
@@ -37,7 +38,8 @@ requirements:
     - mkl_fft
     - numexpr
     - numpy
-    - libopencv
+    - libopencv  # [win]
+    - opencv  # [not win]
     - pywavelets
     - python
     - scikit-image


### PR DESCRIPTION
libopencv is not available from conda-forge


<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->