### PR TITLE
Add CUDA 10.2

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -26,6 +26,14 @@ jobs:
         CONFIG: linux_cuda_compiler_version10.1python3.7
         UPLOAD_PACKAGES: True
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.1
+      linux_cuda_compiler_version10.2python3.6:
+        CONFIG: linux_cuda_compiler_version10.2python3.6
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.2
+      linux_cuda_compiler_version10.2python3.7:
+        CONFIG: linux_cuda_compiler_version10.2python3.7
+        UPLOAD_PACKAGES: True
+        DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.2
       linux_cuda_compiler_version9.2python3.6:
         CONFIG: linux_cuda_compiler_version9.2python3.6
         UPLOAD_PACKAGES: True

--- a/.ci_support/linux_cuda_compiler_version10.2python3.6.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.2python3.6.yaml
@@ -1,0 +1,25 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '10.2'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-cuda:10.2
+numpy:
+- '1.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.6'
+zip_keys:
+- - cuda_compiler_version
+  - docker_image

--- a/.ci_support/linux_cuda_compiler_version10.2python3.7.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.2python3.7.yaml
@@ -1,0 +1,25 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- '10.2'
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-cuda:10.2
+numpy:
+- '1.14'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '3.7'
+zip_keys:
+- - cuda_compiler_version
+  - docker_image

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_cuda_compiler_version10.2python3.6</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5465&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tomopy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.2python3.6" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_cuda_compiler_version10.2python3.7</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5465&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tomopy-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.2python3.7" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_cuda_compiler_version9.2python3.6</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5465&branchName=master">


### PR DESCRIPTION
Hi! This is the friendly automated conda-forge-webservice.

I've rerendered the recipe as instructed in #28.

Here's a checklist to do before merging.
- [ ] Bump the build number if needed.

Fixes #28

Adds CUDA 10.2 now that this is included in conda-forge by default thanks to PR ( https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/377 ).