### PR TITLE
BUG: tomopy cannot depend on MKL

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,8 +29,8 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://github.com/tomopy/tomopy/archive/refs/tags/{{ version }}.tar.gz
-    sha256: b80fdbded4944657bcab48476cb3e2049d34197c8a4f8e6719e46ead4130821e
+  - url: https://github.com/tomopy/tomopy/releases/download/{{ version }}/tomopy-{{ version }}.zip
+    sha256: 815cb993e445962235f6098a0405415bd170ed495227acb70adb973d8f648e81
     patches:
       - shared-cuda-npp.patch
     # There is a special alpha release for only tomopy, so it does not make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.12.2" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 # Set CUDA related variables
 {% if cuda_compiler_version is not defined or cuda_compiler_version == "None" %}
@@ -16,11 +16,9 @@
 {% if win or osx or linux32 or linux64 %}
   {% set use_mkl = "ON" %}
   {% set libfft = "mkl-devel" %}
-  {% set pyfft = "mkl_fft" %}
 {% else %}
   {% set use_mkl = "OFF" %}
   {% set libfft = "nomkl" %}
-  {% set pyfft = "nomkl" %}
 {% endif %}
 
 # Set OpenCV related variables
@@ -101,7 +99,6 @@ outputs:
         - setuptools_scm_git_archive
       run:
         - {{ pin_subpackage('libtomo') }}
-        - {{ pyfft }}
         - importlib_metadata
         - numexpr =2.*
         - numpy >1.12,!=1.22.4


### PR DESCRIPTION
Because:
- powerpc and arm do not have MKL packages, so depending on MKL makes the noarch tomopy uninstallable on them

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
