### PR TITLE
Update numpy and scipy version constraints in meta.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.15.2" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # Set CUDA related variables
 {% if cuda_compiler_version is not defined or cuda_compiler_version == "None" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -117,11 +117,11 @@ outputs:
         - {{ pin_subpackage('libtomo') }}
         - importlib-metadata
         - numexpr >=2.0,<3
-        - numpy >1.12,!=1.22.4
+        - numpy >=2.0,<3
         - pywavelets >=1.0,<2
         - python >=3.6,<4
         - scikit-image >=0.17,<1
-        - scipy >=1.0,<1.14
+        - scipy >=1.0,<2
         - tifffile >=2019
       run_constrained:
         - astra-toolbox >1.8,<3


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Since Tomopy v1.15.1, the issue related to using `numpy 2.x` is already fixed.
However, the build recipe still specifies `scipy < 1.14`, which is incompatible with `numpy 2.x`, which renders the `numpy 2.x` ineffective.
This PR will remove the incorrect cap, allowing `tomopy` to truly work with `numpy 2.x`.

<!--
Please add any other relevant info below:
-->
